### PR TITLE
Add badge email option and uniform indicator on events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castellers-ui",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/api/castellers.js
+++ b/src/api/castellers.js
@@ -217,8 +217,13 @@ export default {
   async getBadgeMembers(badgeUuid) {
     return apiCall("GET", `/badges/${badgeUuid}/members`, {}, null);
   },
-  async assignBadge(badgeUuid, memberUuids) {
-    return apiCall("POST", `/badges/${badgeUuid}/members`, {}, { memberUuids });
+  async assignBadge(badgeUuid, memberUuids, notifyByEmail = false) {
+    return apiCall(
+      "POST",
+      `/badges/${badgeUuid}/members`,
+      {},
+      { memberUuids, notifyByEmail }
+    );
   },
   async removeBadge(badgeUuid, memberUuids) {
     return apiCall(

--- a/src/components/Event-Component.vue
+++ b/src/components/Event-Component.vue
@@ -45,6 +45,16 @@
                 <span class="tag is-social" v-if="event.type == 'social'">{{
                   $t("events.social")
                 }}</span>
+                <span
+                  class="tag is-uniform"
+                  v-if="event.uniformRequired == 1"
+                  :title="$t('events.uniformRequiredHelp')"
+                >
+                  <span class="icon is-small">
+                    <i class="fas fa-tshirt"></i>
+                  </span>
+                  <span>{{ $t("events.uniform") }}</span>
+                </span>
               </div>
             </div>
           </router-link>

--- a/src/components/EventEdit-Component.vue
+++ b/src/components/EventEdit-Component.vue
@@ -115,6 +115,12 @@
             <o-switch v-model="recurring" variant="info"></o-switch>
           </o-field>
         </div>
+        <div class="field column is-2" v-if="!readonly">
+          <label class="label">{{ $t("events.uniformRequired") }}</label>
+          <o-field>
+            <o-switch v-model="uniformRequiredSwitch" variant="info"></o-switch>
+          </o-field>
+        </div>
         <div
           class="field column is-4"
           v-if="currentEvent.uuid === undefined && recurring"
@@ -153,6 +159,9 @@
             format="dd/MM/yyyy HH:mm"
             :transitions="false"
           />
+        </div>
+        <div class="column is-12" v-if="currentEvent.uniformRequired === 1">
+          <p class="content">{{ $t("events.uniformRequiredHelp") }}</p>
         </div>
         <div class="column is-12">
           <div class="columns">
@@ -542,6 +551,7 @@ export default {
         },
         locationName: "",
         description: "",
+        uniformRequired: 0,
       }, // defaults are set here
       isLoading: false,
       table,
@@ -677,6 +687,14 @@ export default {
       },
       set: function (newUuid) {
         this.currentEvent.uuid = newUuid;
+      },
+    },
+    uniformRequiredSwitch: {
+      get: function () {
+        return this.currentEvent.uniformRequired === 1;
+      },
+      set: function (value) {
+        this.currentEvent.uniformRequired = value ? 1 : 0;
       },
     },
     startDateForCalendar: {

--- a/src/i18n/translations/cat.json
+++ b/src/i18n/translations/cat.json
@@ -50,6 +50,9 @@
     "to": "a",
     "type": "Tipus",
     "until": "Fins el",
+    "uniform": "Uniforme",
+    "uniformRequired": "Uniforme requerit",
+    "uniformRequiredHelp": "Per a aquest esdeveniment, cal portar l'uniforme: camisa oficial i pantalons blancs. Si encara no tens la camisa oficial, porta colors semblants als nostres. Tenim algunes camises de segona mà que et podem deixar, si cal.",
     "update": "Modificar detalls esdeveniment",
     "updateButton": "Modificar l'esdeveniment"
   },
@@ -110,6 +113,7 @@
     "adminTitle": "Gestió d'insígnies",
     "selectBadge": "Insígnia",
     "selectBadgePlaceholder": "-- Trieu una insígnia --",
+    "notifyByEmail": "Enviar un correu als destinataris (membres subscrits als correus)",
     "saveButton": "Desar",
     "series": {
       "welcome": {

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -83,6 +83,9 @@
     "remindersSelectedHidden": "{total} selected ({hidden} not shown by search)",
     "remindersSelectedCount": "{count} selected",
     "recurringEvent": "Recurring event",
+    "uniform": "Uniform",
+    "uniformRequired": "Uniform required",
+    "uniformRequiredHelp": "For this event, the uniform is expected: official shirt and white trousers. If you do not have the official shirt yet, wear similar colours to ours. We have a few second-hand shirts we can lend if needed.",
     "registered": "registered",
     "registered_plural": "registered",
     "show": "Event details",
@@ -205,6 +208,7 @@
     "adminTitle": "Badge management",
     "selectBadge": "Badge",
     "selectBadgePlaceholder": "-- Select a badge --",
+    "notifyByEmail": "Send an email to recipients (members subscribed to emails)",
     "saveButton": "Save",
     "series": {
       "welcome": {

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -94,6 +94,9 @@
     "today": "Aujourd'hui",
     "type": "Type",
     "until": "Jusqu'au",
+    "uniform": "Uniforme",
+    "uniformRequired": "Uniforme de mise",
+    "uniformRequiredHelp": "Pour cet évènement, le port de l'uniforme est de mise : chemise officielle et pantalons blancs. Si tu n'as pas encore la chemise officielle, porte des couleurs semblables aux nôtres. Nous avons quelques chemises de seconde main que l'on peut te prêter, au besoin.",
     "update": "Modifier les informations sur un évènement",
     "updateButton": "Modifier l'évènement"
   },
@@ -206,6 +209,7 @@
     "adminTitle": "Gestion des badges",
     "selectBadge": "Badge",
     "selectBadgePlaceholder": "-- Choisir un badge --",
+    "notifyByEmail": "Envoyer un courriel aux récipiendaires (membres abonnés aux courriels)",
     "saveButton": "Enregistrer",
     "series": {
       "welcome": {

--- a/src/scss/bulma-override.scss
+++ b/src/scss/bulma-override.scss
@@ -34,6 +34,7 @@ $colors: map-merge($colors, (
     "presentation": ($warning, $warning-invert, $warning-light, $warning-dark),
     "practice": ($info, $info-invert, $info-light, $info-dark),
     "social": ($primary, $primary-invert, $primary-light, $primary-dark),
+    "uniform": ($link, $link-invert, $link-light, $link-dark),
     "undefined": ($grey, $grey-invert, $grey-light, $grey-dark),
 ));
 

--- a/src/store/modules/badges.js
+++ b/src/store/modules/badges.js
@@ -26,8 +26,8 @@ const actions = {
   async getBadgeMembers(context, badgeUuid) {
     return api.getBadgeMembers(badgeUuid);
   },
-  async assignBadge(context, { badgeUuid, memberUuids }) {
-    return api.assignBadge(badgeUuid, memberUuids);
+  async assignBadge(context, { badgeUuid, memberUuids, notifyByEmail }) {
+    return api.assignBadge(badgeUuid, memberUuids, notifyByEmail);
   },
   async removeBadge(context, { badgeUuid, memberUuids }) {
     return api.removeBadge(badgeUuid, memberUuids);

--- a/src/views/BadgesAdmin-View.vue
+++ b/src/views/BadgesAdmin-View.vue
@@ -69,6 +69,13 @@
       </div>
 
       <div class="field mt-4">
+        <label class="checkbox">
+          <input type="checkbox" v-model="notifyByEmail" />
+          {{ $t("badges.notifyByEmail") }}
+        </label>
+      </div>
+
+      <div class="field mt-4">
         <button
           class="button is-info"
           :disabled="saving || !hasChanges"
@@ -92,6 +99,7 @@ export default {
       initialHolders: [],
       checked: {},
       memberSearchQuery: "",
+      notifyByEmail: false,
       saving: false,
     };
   },
@@ -184,7 +192,11 @@ export default {
       const toRemove = this.membersToRemove;
       try {
         if (toAdd.length > 0) {
-          await this.assignBadge({ badgeUuid, memberUuids: toAdd });
+          await this.assignBadge({
+            badgeUuid,
+            memberUuids: toAdd,
+            notifyByEmail: this.notifyByEmail,
+          });
         }
         if (toRemove.length > 0) {
           await this.removeBadge({ badgeUuid, memberUuids: toRemove });


### PR DESCRIPTION
Admins can email badge recipients on award; events show when the casteller uniform is required in the form and list cards.