### PR TITLE
Highlight uniform notice on event page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "castellers-ui",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/EventEdit-Component.vue
+++ b/src/components/EventEdit-Component.vue
@@ -160,8 +160,21 @@
             :transitions="false"
           />
         </div>
-        <div class="column is-12" v-if="currentEvent.uniformRequired === 1">
-          <p class="content">{{ $t("events.uniformRequiredHelp") }}</p>
+        <div
+          class="column is-12"
+          v-if="currentEvent.uniformRequired === 1"
+        >
+          <div class="uniform-notice media">
+            <div class="media-left">
+              <span class="icon is-large has-text-link" aria-hidden="true">
+                <i class="fas fa-tshirt fa-2x"></i>
+              </span>
+            </div>
+            <div class="media-content">
+              <p class="title is-6">{{ $t("events.uniformRequired") }}</p>
+              <p class="content">{{ $t("events.uniformRequiredHelp") }}</p>
+            </div>
+          </div>
         </div>
         <div class="column is-12">
           <div class="columns">
@@ -999,3 +1012,22 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.uniform-notice {
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  background-color: #eff5fb;
+  border-left: 4px solid #3273dc;
+  border-radius: 4px;
+}
+.uniform-notice .media-left {
+  margin-right: 1rem;
+}
+.uniform-notice .title {
+  margin-bottom: 0.35rem;
+}
+.uniform-notice .content {
+  margin-bottom: 0;
+}
+</style>

--- a/src/i18n/translations/fr.json
+++ b/src/i18n/translations/fr.json
@@ -95,7 +95,7 @@
     "type": "Type",
     "until": "Jusqu'au",
     "uniform": "Uniforme",
-    "uniformRequired": "Uniforme de mise",
+    "uniformRequired": "Uniforme requis",
     "uniformRequiredHelp": "Pour cet évènement, le port de l'uniforme est de mise : chemise officielle et pantalons blancs. Si tu n'as pas encore la chemise officielle, porte des couleurs semblables aux nôtres. Nous avons quelques chemises de seconde main que l'on peut te prêter, au besoin.",
     "update": "Modifier les informations sur un évènement",
     "updateButton": "Modifier l'évènement"


### PR DESCRIPTION
Rename the French label to Uniforme requis and show the help text with a shirt icon in a more visible notice block.